### PR TITLE
Recognize starting blank lines better

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.3 (11/12/22)
+
+-   update to npm version 2.3.2 which patches issue #10 where starting blank
+    lines were not properly being handled
+
 ## 2.0.2 (11/02/22)
 
 -   documentation updates

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "string-content-sort-cli",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "string-content-sort-cli",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "license": "MIT",
             "dependencies": {
                 "ansi-colors": "^4.1.3",
-                "string-content-sort": "^2.3.0"
+                "string-content-sort": "^2.3.1"
             },
             "bin": {
                 "ssort": "dist/main.js"
@@ -2291,9 +2291,9 @@
             }
         },
         "node_modules/string-content-sort": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.0.tgz",
-            "integrity": "sha512-PIDjxLAOT/qUhdNpAj3lLvX76yFabpOUWemENcM6k0KpP0BSQpkoEUCLFJe7XPgRmlUBlG56TnrTdH63fRWG4w=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.1.tgz",
+            "integrity": "sha512-KyXcH9edgPBd7vFs3OhXEqL2AOYYGUoWaDpr5oASmbh9LLEP/QveY0E0weGiySjBD6eqJBiKRZMeBHKWhmWOBg=="
         },
         "node_modules/string.prototype.trim": {
             "version": "1.2.6",
@@ -4209,9 +4209,9 @@
             "dev": true
         },
         "string-content-sort": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.0.tgz",
-            "integrity": "sha512-PIDjxLAOT/qUhdNpAj3lLvX76yFabpOUWemENcM6k0KpP0BSQpkoEUCLFJe7XPgRmlUBlG56TnrTdH63fRWG4w=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.1.tgz",
+            "integrity": "sha512-KyXcH9edgPBd7vFs3OhXEqL2AOYYGUoWaDpr5oASmbh9LLEP/QveY0E0weGiySjBD6eqJBiKRZMeBHKWhmWOBg=="
         },
         "string.prototype.trim": {
             "version": "1.2.6",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "string-content-sort-cli",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "a cli for the npm package: string-content-sort",
     "homepage": "https://scopedsort.netlify.app",
     "repository": {
@@ -26,7 +26,7 @@
     "license": "MIT",
     "dependencies": {
         "ansi-colors": "^4.1.3",
-        "string-content-sort": "^2.3.0"
+        "string-content-sort": "^2.3.1"
     },
     "devDependencies": {
         "@types/node": "^17.0.6",

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.3.1 (11/12/22)
+
+Make parser recognize starting blank lines better.
+For example if you had the following text (notice the space at the start):
+
+<!-- prettier-ignore -->
+```text
+ 
+- some
+  - text
+```
+
+If you used `recursive`, the output would be:
+
+```text
+
+  - text
+- some
+```
+
 ## 2.3.0 (11/1/22)
 
 Some documentation changes & rename all typos of "seperate" to "separate".

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "string-content-sort",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "string-content-sort",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "license": "MIT",
             "devDependencies": {
+                "@types/tape": "^4.13.2",
                 "@typescript-eslint/eslint-plugin": "^5.40.1",
                 "@typescript-eslint/parser": "^5.40.1",
                 "eslint": "^8.25.0",
@@ -115,11 +116,26 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
+        "node_modules/@types/node": {
+            "version": "18.11.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+            "dev": true
+        },
         "node_modules/@types/semver": {
             "version": "7.3.12",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
             "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
             "dev": true
+        },
+        "node_modules/@types/tape": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@types/tape/-/tape-4.13.2.tgz",
+            "integrity": "sha512-V1ez/RtYRGN9cNYApw5xf27DpMkTB0033X6a2i3KUmKhSojBfbWN0i3EgZxboUG96WJLHLdOyZ01aiZwVW5aSA==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "5.40.1",
@@ -2621,11 +2637,26 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
+        "@types/node": {
+            "version": "18.11.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+            "dev": true
+        },
         "@types/semver": {
             "version": "7.3.12",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
             "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
             "dev": true
+        },
+        "@types/tape": {
+            "version": "4.13.2",
+            "resolved": "https://registry.npmjs.org/@types/tape/-/tape-4.13.2.tgz",
+            "integrity": "sha512-V1ez/RtYRGN9cNYApw5xf27DpMkTB0033X6a2i3KUmKhSojBfbWN0i3EgZxboUG96WJLHLdOyZ01aiZwVW5aSA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "5.40.1",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "string-content-sort",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "sort the content inside of a string",
     "main": "dist/main.js",
     "homepage": "https://scopedsort.netlify.app",
@@ -27,6 +27,7 @@
     "author": "karizma",
     "license": "MIT",
     "devDependencies": {
+        "@types/tape": "^4.13.2",
         "@typescript-eslint/eslint-plugin": "^5.40.1",
         "@typescript-eslint/parser": "^5.40.1",
         "eslint": "^8.25.0",

--- a/npm/src/main.ts
+++ b/npm/src/main.ts
@@ -748,16 +748,22 @@ export function sort(text: string, options: Options = {}) {
         const indentation = match?.groups?.indentation || '';
         const listChar = match?.groups?.char;
 
+        const isBlankLine = isBlankLineRegexTest.test(line);
+
         if (typeof currentIndentation === 'undefined') {
-            currentIndentation = indentation;
+            if (isBlankLine) {
+                currentSection.push(line);
+                continue;
+            } else {
+                currentIndentation = indentation;
+            }
         }
 
         if (currentSection.length && (!options.markdown || listChar)) {
             if (
                 options.sectionStarter
                     ? options.sectionStarter.test(line)
-                    : !isBlankLineRegexTest.test(line) &&
-                      indentation === currentIndentation
+                    : !isBlankLine && indentation === currentIndentation
             ) {
                 sections.push(currentSection.join('\n'));
                 currentSection = [line];

--- a/npm/test/sort.test.js
+++ b/npm/test/sort.test.js
@@ -1917,3 +1917,105 @@ zer`,
 
     t.end();
 });
+
+test('test starting blank lines', (t) => {
+    const textWithStartingSpace = ` 
+- [x] (a0)
+  - [x] (1)
+  - [x] (2)
+    - review [open tasks](searches\open-tasks.code-search)
+  - [x] (3)
+  - [x] (4)
+    - [x] 1)
+    - [x] 2)
+    - [x] 3)
+      - comment 1
+      - comment 2
+      - comment 3
+    - [x] 4)
+    - [x] 5)
+      - comment 1
+        - comment 1.a
+  
+- [ ] (a1)
+  - comment 1
+    - comment 1.a
+    - comment 2
+    - comment 3
+
+- [ ] (z)
+  - [ ] (1)
+    - comment 1
+      - comment 1.a
+  - [ ] (2)
+    comment 1
+    - comment 2
+  - [ ] (3)
+  - [ ] (4)
+  - [ ] (5)
+    - comment 1`;
+
+    testString(
+        t,
+        sort(textWithStartingSpace, { recursive: true }),
+        ` 
+- [ ] (a1)
+  - comment 1
+    - comment 1.a
+    - comment 2
+    - comment 3
+
+- [ ] (z)
+  - [ ] (1)
+    - comment 1
+      - comment 1.a
+  - [ ] (2)
+    - comment 2
+    comment 1
+  - [ ] (3)
+  - [ ] (4)
+  - [ ] (5)
+    - comment 1
+- [x] (a0)
+  - [x] (1)
+  - [x] (2)
+    - review [open tasks](searchesopen-tasks.code-search)
+  - [x] (3)
+  - [x] (4)
+    - [x] 1)
+    - [x] 2)
+    - [x] 3)
+      - comment 1
+      - comment 2
+      - comment 3
+    - [x] 4)
+    - [x] 5)
+      - comment 1
+        - comment 1.a
+  `,
+        'starting space'
+    );
+
+    testString(
+        t,
+        sort(`
+
+
+- hi there
+- this is some text
+  - yea?
+- oh yea
+  - temp`),
+        `
+
+
+- hi there
+- oh yea
+  - temp
+- this is some text
+  - yea?`,
+        'few empty lines at start'
+    );
+
+    t.end();
+});

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Changelog
 
+## 3.1.1 (11/12/22)
+
+-   update to npm version 2.3.2 which patches issue #10 where starting blank
+    lines were not properly being handled
+
 ## 3.1.0 (11/2/22)
 
 -   implement [string-content-sort@2.3.0](https://www.npmjs.com/package/string-content-sort),

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,14 +1,14 @@
 {
     "name": "scoped-sort",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "scoped-sort",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "dependencies": {
-                "string-content-sort": "^2.3.0"
+                "string-content-sort": "^2.3.1"
             },
             "devDependencies": {
                 "@types/mocha": "^10.0.0",
@@ -2820,9 +2820,9 @@
             }
         },
         "node_modules/string-content-sort": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.0.tgz",
-            "integrity": "sha512-PIDjxLAOT/qUhdNpAj3lLvX76yFabpOUWemENcM6k0KpP0BSQpkoEUCLFJe7XPgRmlUBlG56TnrTdH63fRWG4w=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.1.tgz",
+            "integrity": "sha512-KyXcH9edgPBd7vFs3OhXEqL2AOYYGUoWaDpr5oASmbh9LLEP/QveY0E0weGiySjBD6eqJBiKRZMeBHKWhmWOBg=="
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -5280,9 +5280,9 @@
             }
         },
         "string-content-sort": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.0.tgz",
-            "integrity": "sha512-PIDjxLAOT/qUhdNpAj3lLvX76yFabpOUWemENcM6k0KpP0BSQpkoEUCLFJe7XPgRmlUBlG56TnrTdH63fRWG4w=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.1.tgz",
+            "integrity": "sha512-KyXcH9edgPBd7vFs3OhXEqL2AOYYGUoWaDpr5oASmbh9LLEP/QveY0E0weGiySjBD6eqJBiKRZMeBHKWhmWOBg=="
         },
         "string-width": {
             "version": "4.2.3",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "scoped-sort",
     "displayName": "Scoped Sort",
     "description": "A feature rich sorter for vscode.",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "publisher": "karizma",
     "icon": "assets/scoped-sort-red-circle.png",
     "main": "./dist/extension.js",
@@ -106,6 +106,6 @@
         "tape": "^5.2.2"
     },
     "dependencies": {
-        "string-content-sort": "^2.3.0"
+        "string-content-sort": "^2.3.1"
     }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,7 +13,7 @@
 				"rehype-autolink-headings": "^6.1.1",
 				"rehype-slug": "^5.0.1",
 				"shiki-twoslash": "^3.1.0",
-				"string-content-sort": "^2.2.0"
+				"string-content-sort": "^2.3.1"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "next",
@@ -2213,9 +2213,9 @@
 			}
 		},
 		"node_modules/string-content-sort": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.2.0.tgz",
-			"integrity": "sha512-cmZGUmZaw43GHXiUZRxLI/MRhvhzZ+g0Ha6MgM6zOGUET9XdLnUW4l+2vpKAaQ18i+Ib6FjqFNAF1gh4kZV5sg=="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.1.tgz",
+			"integrity": "sha512-KyXcH9edgPBd7vFs3OhXEqL2AOYYGUoWaDpr5oASmbh9LLEP/QveY0E0weGiySjBD6eqJBiKRZMeBHKWhmWOBg=="
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
@@ -4237,9 +4237,9 @@
 			}
 		},
 		"string-content-sort": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.2.0.tgz",
-			"integrity": "sha512-cmZGUmZaw43GHXiUZRxLI/MRhvhzZ+g0Ha6MgM6zOGUET9XdLnUW4l+2vpKAaQ18i+Ib6FjqFNAF1gh4kZV5sg=="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/string-content-sort/-/string-content-sort-2.3.1.tgz",
+			"integrity": "sha512-KyXcH9edgPBd7vFs3OhXEqL2AOYYGUoWaDpr5oASmbh9LLEP/QveY0E0weGiySjBD6eqJBiKRZMeBHKWhmWOBg=="
 		},
 		"string-width": {
 			"version": "4.2.3",

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,6 @@
 		"rehype-autolink-headings": "^6.1.1",
 		"rehype-slug": "^5.0.1",
 		"shiki-twoslash": "^3.1.0",
-		"string-content-sort": "^2.2.0"
+		"string-content-sort": "^2.3.1"
 	}
 }


### PR DESCRIPTION
The indentation level was determined by the first line regardless if it contained any non white space characters. 

This was fine even for the most part, but if the first line had only white space characters, it would still set the indentation level to that, when it should be ignored.

For example, the following text sorted with `recursive`:
(note: there is a space on the first line)
```text
 
- some
  - text
```

will result in:

```text
 
  - text
- some
```

Fixes #10.